### PR TITLE
Flatten dicts and lists to PHP-readable POST fields

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,7 +45,7 @@ class AppendQsTestCase(TestCase):
 class FlattenDictPhpArrayTestCase(TestCase):
     def test_single_level_dict(self):
         data = {'dict': {'key': 'value'}}
-        result = utils.convert_to_php_post(data)
+        result = utils.to_nested_php_args(data)
         self.assertEqual(result, {'dict[key]': 'value'})
 
     def test_nested_dicts(self):
@@ -58,12 +58,12 @@ class FlattenDictPhpArrayTestCase(TestCase):
                 }
             }
         }
-        result = utils.convert_to_php_post(data)
+        result = utils.to_nested_php_args(data)
         self.assertEqual(result, {'dict[muffin][taco][puffin]': 'value'})
 
     def test_lists(self):
         data = {'top': {'list': ['a', 'b', 'c']}}
-        result = utils.convert_to_php_post(data)
+        result = utils.to_nested_php_args(data)
         self.assertEqual(result, {
             'top[list][0]': 'a',
             'top[list][1]': 'b',
@@ -72,7 +72,7 @@ class FlattenDictPhpArrayTestCase(TestCase):
 
     def test_accepts_list_of_tuples(self):
         data = [('top', {'list': ['a', 'b', 'c']})]
-        result = utils.convert_to_php_post(data)
+        result = utils.to_nested_php_args(data)
         self.assertEqual(result, [
             ('top[list][2]', 'c'),
             ('top[list][0]', 'a'),

--- a/ubersmith/api.py
+++ b/ubersmith/api.py
@@ -12,7 +12,7 @@ from ubersmith.exceptions import (
     ResponseError,
     UpdatingTokenResponse,
 )
-from ubersmith.utils import append_qs, urlencode_unicode, convert_to_php_post
+from ubersmith.utils import append_qs, urlencode_unicode, to_nested_php_args
 
 __all__ = [
     'METHODS',
@@ -245,7 +245,7 @@ class _AbstractRequestHandler(object):
     def _encode_data(self, data):
         """URL encode data."""
         data = data if data is not None else {}
-        data = convert_to_php_post(data)
+        data = to_nested_php_args(data)
         return urlencode_unicode(data)
 
     def __getattr__(self, name):


### PR DESCRIPTION
This bit me today, trying to do a `client.service_update(service_id=1, options={2: 3})`. Where it should be sending "options[2]=3", it instead sends "options={2:3}". Here's a fix!
