### PR TITLE
Make requirements more permissive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.3.0
-phpserialize==1.3
-six==1.6.1
+requests>=2.3.0
+phpserialize>=1.3
+six>=1.6.1


### PR DESCRIPTION
This will allow a project requiring six>=1.7.0 for example to use this package.
