### PR TITLE
fix(init): auto load submodules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.3.0
 phpserialize>=1.3
-six>=1.6.1
+six>=1.7

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ubersmith',
-    version='0.3.9',
+    version='0.3.10',
     author='Jason Keene',
     author_email='jasonkeene@gmail.com',
     description='Client library for the Ubersmith API 2.0',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,5 @@
+import sys
+from six.moves import reload_module
 from mock import Mock
 
 import ubersmith
@@ -13,3 +15,19 @@ def it_sets_default_request_handler(monkeypatch):
     assert handler.username == 'X-username'
     assert handler.password == 'X-password'
     assert handler.verify == 'X-verify'
+
+
+def it_imports_call_modules():
+    """Ensure ubersmith.xyz is available if we just import ubersmith"""
+
+    # Clear out all ubersmith submodules, so reload() below doesn't reuse them
+    for name in list(sys.modules):
+        if name.startswith('ubersmith.') or name == 'ubersmith':
+            del sys.modules[name]
+
+    # Load module afresh
+    import ubersmith
+    ubersmith = reload_module(ubersmith)
+
+    for name in ubersmith.__all__:
+        assert hasattr(ubersmith, name)

--- a/ubersmith/__init__.py
+++ b/ubersmith/__init__.py
@@ -1,4 +1,16 @@
 from ubersmith.api import RequestHandler, set_default_request_handler
+from ubersmith import (
+    api,
+    exceptions,
+    utils,
+    calls,
+    client,
+    device,
+    order,
+    sales,
+    support,
+    uber,
+)
 
 __all__ = [
     # package modules


### PR DESCRIPTION
Allows the use of ubersmith.client, etc, by only importing `ubersmith`. As it stands, ubersmith's `__init__.py` includes its submodules in `__all__`, but does not actually import them. This can lead to seemingly weird behaviour where `ubersmith.client.get()` works only if you import one of your other modules that does `import ubersmith.client` directly.

To demonstrate this behaviour, try this out in the Python console:

```python
>>> import ubersmith
>>> ubersmith.client.get(client_id=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'client'
```